### PR TITLE
add command line option to write cactus grapg to graphml file

### DIFF
--- a/app/mincut.cpp
+++ b/app/mincut.cpp
@@ -81,6 +81,11 @@ int main(int argn, char** argv) {
         cfg->find_most_balanced_cut = true;
     }
 
+    if (cfg->cactus_filename != "" ) {
+        // need save_cut to properly maintain containedVertices, see https://github.com/VieCut/VieCut/issues/7
+	cfg->save_cut = true;
+    }
+
     std::vector<int> numthreads;
     timer t;
     GraphPtr G = graph_io::readGraphWeighted<graph_type>(

--- a/app/mincut.cpp
+++ b/app/mincut.cpp
@@ -70,6 +70,8 @@ int main(int argn, char** argv) {
     cmdl.add_flag('v', "verbose", cfg->verbose, "more verbose logs");
     cmdl.add_string('e', "edge_select", cfg->edge_selection, "NNI edge select");
     cmdl.add_size_t('r', "seed", cfg->seed, "random seed");
+    cmdl.add_string('t', "cactus_filename", cfg->cactus_filename,
+                    "name of GraphML file for the cactus graph");
 
     if (!cmdl.process(argn, argv))
         return -1;

--- a/lib/common/configuration.h
+++ b/lib/common/configuration.h
@@ -78,6 +78,9 @@ class configuration {
     bool blacklist = true;
     bool set_node_in_cut = false;
 
+    // cactus graph output
+    std::string cactus_filename = "";
+
     // dynamic minimum cut
     size_t depthOfPartialRelabeling = 1;
 


### PR DESCRIPTION
Additional code for exporting the cactus graph. There are no tests yet.

The cactus graph can now be exported via the command
```
mincut <metis_file_name> cactus -t <cactus_file_name>
```
The file `cactus_file_name` contains the cactus graph along with the information about the "contained vertices" as node labels in the standard GraphML format.